### PR TITLE
Fix emails not being shown in the API response

### DIFF
--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -41,6 +41,7 @@ class DiscourseAPI
         }
         $paramArray['api_key'] = $this->_apiKey;
         $paramArray['api_username'] = $apiUser;
+        $paramArray['show_emails'] = 'true';
         $ch = curl_init();
         $url = sprintf(
             '%s://%s%s?%s',


### PR DESCRIPTION
Since a recent version of discourse, you have to specify that you want the emails to be shown in the response.
