### PR TITLE
API for creating a post does not require category

### DIFF
--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -398,12 +398,11 @@ class DiscourseAPI
      * NOT WORKING YET
      */
 
-    function createPost($bodyText, $topicId, $categoryId, $userName)
+    function createPost($bodyText, $topicId, $userName)
     {
         $params = array(
             'raw' => $bodyText,
             'archetype' => 'regular',
-            'category' => $categoryId,
             'topic_id' => $topicId
         );
         return $this->_postRequest('/posts', $params, $userName);


### PR DESCRIPTION
https://meta.discourse.org/t/discourse-api-documentation/22706/140

The comment on line 398 says this function does not work yet, but I think this will make it work. Hitting the API manually with a topic ID and the raw post content works fine, for example.
