### PR TITLE
Use members.json

### DIFF
--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -502,7 +502,7 @@ class DiscourseAPI
             $params = array(
                 'usernames' => $username
             );
-         return $this->_putRequest('/groups/' . $groupId . '/members', $params);
+         return $this->_putRequest('/groups/' . $groupId . '/members.json', $params);
          }
      }
 


### PR DESCRIPTION
According to Discourse documentation, the right endpoint is `members.json` and not `members`