### PR TITLE
Change auth from query params to header-based

### DIFF
--- a/src/DiscourseAPI.php
+++ b/src/DiscourseAPI.php
@@ -586,12 +586,14 @@
          **/
         private function _getRequest(string $reqString, array $paramArray = [], string $apiUser = 'system', $HTTPMETHOD = 'GET'): \stdClass
         {
-            $paramArray['api_key']      = $this->_apiKey;
-            $paramArray['api_username'] = $apiUser;
             $paramArray['show_emails']  = 'true';
             $ch                         = curl_init();
             $url                        = sprintf('%s://%s%s?%s', $this->_protocol, $this->_dcHostname, $reqString, http_build_query($paramArray));
             curl_setopt($ch, CURLOPT_URL, $url);
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+                "Api-Key: " . $this->_apiKey,
+                "Api-Username: " . $apiUser
+            ));
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $HTTPMETHOD);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
@@ -621,7 +623,7 @@
         private function _putpostRequest(string $reqString, array $paramArray, string $apiUser = 'system', $HTTPMETHOD = 'POST'): \stdClass
         {
             $ch  = curl_init();
-            $url = sprintf('%s://%s%s?api_key=%s&api_username=%s', $this->_protocol, $this->_dcHostname, $reqString, $this->_apiKey, $apiUser);
+            $url = sprintf('%s://%s%s', $this->_protocol, $this->_dcHostname, $reqString);
             curl_setopt($ch, CURLOPT_URL, $url);
             $query = '';
             if (isset($paramArray['group']) && is_array($paramArray['group'])) {
@@ -634,6 +636,10 @@
                 }
             }
             $query = trim($query, '&');
+            curl_setopt($ch, CURLOPT_HTTPHEADER, array(
+                "Api-Key: " . $this->_apiKey,
+                "Api-Username: " . $apiUser
+            ));
             curl_setopt($ch, CURLOPT_POSTFIELDS, $query);
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
             curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $HTTPMETHOD);


### PR DESCRIPTION
Discourse is deprecating query-based auth in favor of header-based auth
per this forum post:

https://meta.discourse.org/t/discourse-api-documentation/22706

This change updates this library to use HTTP header-based auth